### PR TITLE
Add debian 12 support, remove Ubuntu 18.04

### DIFF
--- a/.github/workflows/panel.yml
+++ b/.github/workflows/panel.yml
@@ -25,6 +25,7 @@ jobs:
           - ubuntu_jammy
           - debian_buster
           - debian_bullseye
+          - debian_bookworm
           - rockylinux_8
           - rockylinux_9
           - almalinux_8

--- a/.github/workflows/panel.yml
+++ b/.github/workflows/panel.yml
@@ -20,7 +20,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu_bionic
           - ubuntu_focal
           - ubuntu_jammy
           - debian_buster

--- a/.github/workflows/panel.yml
+++ b/.github/workflows/panel.yml
@@ -1,6 +1,10 @@
 name: Test Panel Installer
 
 on:
+  schedule:
+    # At 09:00 on Saturday
+    - cron: "0 9 * * 6"
+
   push:
     paths:
       - "installers/panel.sh"

--- a/.github/workflows/wings.yml
+++ b/.github/workflows/wings.yml
@@ -25,6 +25,7 @@ jobs:
           - ubuntu_jammy
           - debian_buster
           - debian_bullseye
+          - debian_bookworm
           - rockylinux_8
           - rockylinux_9
           - almalinux_8

--- a/.github/workflows/wings.yml
+++ b/.github/workflows/wings.yml
@@ -20,7 +20,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu_bionic
           - ubuntu_focal
           - ubuntu_jammy
           - debian_buster

--- a/.github/workflows/wings.yml
+++ b/.github/workflows/wings.yml
@@ -1,6 +1,10 @@
 name: Test Wings Installer
 
 on:
+  schedule:
+    # At 09:00 on Saturday
+    - cron: "0 9 * * 6"
+
   push:
     paths:
       - "installers/wings.sh"

--- a/README.md
+++ b/README.md
@@ -33,13 +33,14 @@ List of supported installation setups for panel and Wings (installations support
 | ---------------- | ------- | ------------------ | ----------- |
 | Ubuntu           | 14.04   | :red_circle:       |             |
 |                  | 16.04   | :red_circle: \*    |             |
-|                  | 18.04   | :white_check_mark: | 8.1         |
+|                  | 18.04   | :red_circle: \*    | 8.1         |
 |                  | 20.04   | :white_check_mark: | 8.1         |
 |                  | 22.04   | :white_check_mark: | 8.1         |
 | Debian           | 8       | :red_circle: \*    |             |
 |                  | 9       | :red_circle: \*    |             |
 |                  | 10      | :white_check_mark: | 8.1         |
 |                  | 11      | :white_check_mark: | 8.1         |
+|                  | 12      | :white_check_mark: | 8.1         |
 | CentOS           | 6       | :red_circle:       |             |
 |                  | 7       | :red_circle: \*    |             |
 |                  | 8       | :red_circle: \*    |             |
@@ -88,9 +89,9 @@ Replace name with one of the following (supported installations).
 
 - `ubuntu_jammy`
 - `ubuntu_focal`
-- `ubuntu_bionic`
 - `debian_bullseye`
 - `debian_buster`
+- `debian_bookworm`
 - `almalinux_8`
 - `almalinux_9`
 - `rockylinux_8`

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,10 +17,6 @@ Vagrant.configure("2") do |config|
     ubuntu_focal.vm.box = "ubuntu/focal64"
   end
 
-  config.vm.define "ubuntu_bionic" do |ubuntu_bionic|
-    ubuntu_bionic.vm.box = "ubuntu/bionic64"
-  end
-
   # debian
   config.vm.define "debian_bullseye" do |debian_bullseye|
     debian_bullseye.vm.box = "debian/bullseye64"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,6 +30,10 @@ Vagrant.configure("2") do |config|
     debian_buster.vm.box = "debian/buster64"
   end
 
+  config.vm.define "debian_bookworm" do |debian_bookworm|
+    debian_bookworm.vm.box = "debian/bookworm64"
+  end
+
   config.vm.define "almalinux_8" do |almalinux_8|
     almalinux_8.vm.box = "almalinux/8"
   end

--- a/installers/panel.sh
+++ b/installers/panel.sh
@@ -252,9 +252,6 @@ ubuntu_dep() {
   # Add Ubuntu universe repo
   add-apt-repository universe -y
 
-  # Add the MariaDB repo (bionic has mariadb version 10.1 and we need newer than that)
-  [ "$OS_VER_MAJOR" == "18" ] && curl -sS https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | bash
-
   # Add PPA for PHP (we need 8.1)
   LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/php
 }

--- a/installers/wings.sh
+++ b/installers/wings.sh
@@ -81,8 +81,6 @@ dep_install() {
     mkdir -p /etc/apt/keyrings
     curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor --yes -o /etc/apt/keyrings/docker.gpg
 
-    [ "$INSTALL_MARIADB" == true ] && [ "$OS_VER_MAJOR" == "18" ] && curl -sS "$MARIADB_URL" | bash
-
     echo \
       "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/$OS \
       $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list >/dev/null

--- a/lib/lib.sh
+++ b/lib/lib.sh
@@ -536,6 +536,7 @@ ubuntu)
 debian)
   [ "$OS_VER_MAJOR" == "10" ] && SUPPORTED=true
   [ "$OS_VER_MAJOR" == "11" ] && SUPPORTED=true
+  [ "$OS_VER_MAJOR" == "12" ] && SUPPORTED=true
   export DEBIAN_FRONTEND=noninteractive
   ;;
 rocky | almalinux)

--- a/lib/lib.sh
+++ b/lib/lib.sh
@@ -528,7 +528,6 @@ esac
 
 case "$OS" in
 ubuntu)
-  [ "$OS_VER_MAJOR" == "18" ] && SUPPORTED=true
   [ "$OS_VER_MAJOR" == "20" ] && SUPPORTED=true
   [ "$OS_VER_MAJOR" == "22" ] && SUPPORTED=true
   export DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Adds Debian 12 to workflows,
Supports it in `lib.sh`
Removes Ubuntu 18.04
Adds a periodic run of the workflows

Fixes #416 
