### PR TITLE
Europe/Kiev renamed to Europe/Kyiv

### DIFF
--- a/configs/valid_timezones.txt
+++ b/configs/valid_timezones.txt
@@ -271,7 +271,7 @@ Europe/Gibraltar
 Europe/Helsinki
 Europe/Istanbul
 Europe/Kaliningrad
-Europe/Kiev
+Europe/Kyiv
 Europe/Kirov
 Europe/Lisbon
 Europe/London


### PR DESCRIPTION
This pull request fixes an error during the installation process by renaming Europe/Kiev renamed to Europe/Kyiv as Europe/Kiev is not a valid PHP timezone.